### PR TITLE
[PROV-444] feat: automate cimg/gcp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,23 @@
 version: 2.1
 
+orbs:
+  gh: circleci/github-cli@2.2.0
+
+parameters:
+  trigger:
+    type: boolean
+    default: false
+
 workflows:
-  main:
+  automated-wf:
+    when: << pipeline.parameters.trigger >>
+    jobs:
+      - check-feed:
+          context:
+            - cimg-publishing
+  main-wf:
+    when:
+      not: << pipeline.parameters.trigger >>
     jobs:
       - build:
           context: cimg-publishing
@@ -9,11 +25,11 @@ workflows:
 jobs:
   build:
     docker:
-      - image: cimg/base:2022.06
+      - image: cimg/base:current
     steps:
       - checkout
       - setup_remote_docker:
-          version: "20.10.14"
+          version: "docker24"
       - run:
           name: "Build Docker Images"
           command: |
@@ -23,9 +39,9 @@ jobs:
           name: "Publish Docker Images (main branch only)"
           command: |
             if [ "${CIRCLE_BRANCH}" == "main" ]; then
-              
+
               echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
-              
+
               # an else block will be added in the future for a staging release
               if git log -1 --pretty=%s | grep "\[release\]"; then
                 echo "Publishing cimg/gcp to Docker Hub production."
@@ -34,3 +50,46 @@ jobs:
                 echo "Skipping publishing."
               fi
             fi
+
+  check-feed:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "f8:07:0f:f6:b5:eb:57:ae:be:4d:2f:2d:be:70:8f:ff"
+      - run:
+          name: SSH config to pull and push project
+          command: |
+            ssh-add -D
+            ssh-add ~/.ssh/id_rsa_f8070ff6b5eb57aebe4d2f2dbe708fff
+            ssh-keygen -f ~/.ssh/id_rsa_f8070ff6b5eb57aebe4d2f2dbe708fff -y > ~/.ssh/id_rsa_f8070ff6b5eb57aebe4d2f2dbe708fff.pub
+            echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFHZoU4/njm1peseKCHfY4igdb4cbVwK16ADNlIoj6Ch secops+cpe-image-bot@circleci.com" > ~/.ssh/allowed_signers
+      - run:
+          name: Run git config
+          command: |
+            cat \<<'EOF' >> ~/githelper.sh
+              #!/usr/bin/env bash
+              echo username=$GIT_USERNAME
+              echo password=$IMAGE_BOT_TOKEN
+            EOF
+
+            git config --global user.email "secops+cpe-image-bot@circleci.com"
+            git config --global user.name "cpe-image-bot"
+            git config --global user.signingkey "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFHZoU4/njm1peseKCHfY4igdb4cbVwK16ADNlIoj6Ch"
+            git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers
+            git config --global url."https://github.com".insteadOf ssh://git@github.com
+            git config --global url."https://github.com/".insteadOf git@github.com:
+            git config --global credential.helper "/bin/bash ~/githelper.sh"
+            git config --global gpg.format ssh
+            git config --global commit.gpgsign true
+            git submodule sync
+      - gh/setup:
+          token: IMAGE_BOT_TOKEN
+      - run:
+          name: Run version update script
+          command: |
+            sudo chmod +x gcpFeed.sh
+            git submodule update --init --recursive
+            ./gcpFeed.sh

--- a/gcpFeed.sh
+++ b/gcpFeed.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+if [ -f shared/automated-updates.sh ]; then
+  source shared/automated-updates.sh
+else
+  echo "Check if submodule was loaded; automated-updates.sh is missing"
+  exit 1
+fi
+source ./manifest
+
+templateFile="Dockerfile.template"
+interval="monthly"
+VERSION=$( date +%Y.%m )
+
+replaceDatedTags "$templateFile" "$interval"
+releaseDeployImage "$VERSION"


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
A brief description of the changes in this PR.
set up automation for cimg/aws based off a triggered build when cimg/deploy is released

# Reasons
Please provide reasoning for these changes and how this PR achieves them.
part of efforts to automate the deploy-suite of cimgs, which are released on a monthly basis

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
