### PR TITLE
issues/27 Use cloud.googld.gpg from gcloud docs, migrate to kube comm…

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -8,7 +8,9 @@ LABEL maintainer="CircleCI Execution Team <eng-execution@circleci.com>"
 
 # Install GCP related tools
 RUN echo "deb [signed-by=/etc/apt/trusted.gpg.d/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-	curl -fsSLo - https://dl.k8s.io/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/cloud.google.gpg && \
+	curl -fsSLo - https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/cloud.google.gpg && \
+	echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list && \
+	curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg && \
 	sudo apt-get update && sudo apt-get install --yes --no-install-recommends \
 		google-cloud-cli \
 		google-cloud-cli-app-engine-go \


### PR DESCRIPTION
…unity repos

For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
Fixes apt failures by using gcloud gpg from gcloud docs, migrating to kube community repos

# Reasons
apt throwing GPG error for packages.cloud.google.com/apt repo.  The gcloud docs specify where to get the gpg key file: https://cloud.google.com/sdk/docs/install-sdk#deb

apt throwing GPG error for apt.kubernetes.io.  The kubernetes blog specifies how to migrate from this deprecated repo to the new kube community repos: https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/#how-to-migrate

https://github.com/CircleCI-Public/cimg-gcp/issues/27

# Checklist

Please check through the following before opening your PR. Thank you!

- [X] I have made changes to the `Dockerfile.template` file only
- [X] I have not made any manual changes to automatically generated files
- [X] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
